### PR TITLE
12 write tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ python-setup:
 	env-ads/bin/pip install -r requirements.txt
 
 python-run:
-	python cli.py data/keywords.csv data/ads.csv
+	env-ads/bin/python cli.py data/keywords.csv data/ads.csv
 
 # additional commands
 notebook:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ notebook:
 	jupyter notebook
 
 test:
-	pytest
+	env-ads/bin/pytest -vv	
 
 lint:
 	env-ads/bin/pylint adscraper

--- a/tests/test.csv
+++ b/tests/test.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2186409f55edd9a01f1517f4a7c8dc8bd623ddcae5bfd58e070eb675215704b3
+size 26

--- a/tests/test_csv_handler.py
+++ b/tests/test_csv_handler.py
@@ -4,7 +4,7 @@ from adscraper import csv_handler
 
 def test_get_keywords():
     # test if file gets open correctly
-    assert csv_handler.get_keywords('data/keywords.csv')
+    assert csv_handler.get_keywords('tests/test.csv')
 
     # test if Error gets raised when file not exists
     with pytest.raises(FileNotFoundError):

--- a/tests/test_csv_handler.py
+++ b/tests/test_csv_handler.py
@@ -9,3 +9,8 @@ def test_get_keywords():
     # test if Error gets raised when file not exists
     with pytest.raises(FileNotFoundError):
         csv_handler.get_keywords('foo.csv')
+
+    # test if right keywords get extracted
+    keywords = csv_handler.get_keywords('tests/test.csv')
+    test_keywords = ["This ", "Are", "TEST", "keywords"]
+    assert keywords == test_keywords


### PR DESCRIPTION
# Description

Changes:
* Expand test for csv_handler.get_keywords
* Let tests.test_csv_handler use dummy data
* Fix make test
  * make test now uses pytest of the vitualenv
  * show the more detailed test results
Fixes # (issue)

# How Has This Been Tested?

- [x] `make test`
- [x] `make python-setup python-run`
- [x] `make docker-setup docker-run`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
